### PR TITLE
add/ service accounts (for deploy from CI, for assign to an app and run it)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ provider "google" {
   region      = var.region
 }
 
-resource "google_artifact_registry_repository" "default" {
+resource "google_artifact_registry_repository" "go-echo-sandbox" {
   location      = var.region
   repository_id = var.repository_id
   description   = "Cloud run application docker repository"

--- a/service_account_deploy.tf
+++ b/service_account_deploy.tf
@@ -1,0 +1,17 @@
+resource "google_service_account" "deploy" {
+  account_id   = "go-echo-sandbox-deploy"
+  display_name = "go-echo-sandbox-deploy"
+
+  project = var.project
+}
+
+resource "google_project_iam_member" "deploy" {
+  for_each = toset([
+    "roles/run.admin",
+    "roles/artifactregistry.writer",
+  ])
+
+  project = var.project
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}

--- a/service_account_run.tf
+++ b/service_account_run.tf
@@ -1,0 +1,17 @@
+resource "google_service_account" "run" {
+  account_id   = "go-echo-sandbox-run"
+  display_name = "go-echo-sandbox-run"
+
+  project = var.project
+}
+
+resource "google_project_iam_member" "run" {
+  for_each = toset([
+    "roles/run.invoker",
+    "roles/secretmanager.secretAccessor",
+  ])
+
+  project = var.project
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.run.email}"
+}


### PR DESCRIPTION
# About

Prepare Service Accounts.

## Ref
- PR
  - https://github.com/miolab/tf_cloud_run_go_sample/pull/1
- Role
  - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam
  - https://cloud.google.com/iam/docs/understanding-roles?hl=ja
  - https://cloud.google.com/artifact-registry/docs/access-control?hl=ja
  - https://cloud.google.com/run/docs/reference/iam/roles
- Others
  - https://blog.g-gen.co.jp/entry/cloud-run-explained
  - https://zenn.dev/yamakoo/articles/93bb97cf1df040
  - https://zenn.dev/yamakoo/articles/93bb97cf1df040
